### PR TITLE
Fix channels for FlipChannels

### DIFF
--- a/seismic_augmentation/augmentations.py
+++ b/seismic_augmentation/augmentations.py
@@ -55,7 +55,10 @@ class FlipChannels(BaseAugmentation):
         assert data.size(0) == 3, "You need 3-component waveform to use this augmentation"
 
         permute = [0, 2, 1]
-        return data[:, permute]
+        permuted = data[permute, :]
+
+        assert permuted.size() == data.size()
+        return permuted
 
 
 class AddRandomNoise(BaseAugmentation):


### PR DESCRIPTION
This change alighns the channels in the correct order for the input of torch.Size([3, <wave_len>]) so that the output is of the same size torch.Size([3,  <wave_len>])